### PR TITLE
Core/Movement: Fix warrior charge animation

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -322,7 +322,7 @@ void WorldSession::HandleMovementOpcodes(WorldPacket & recvData)
     // pussywizard: typical check for incomming movement packets
     if (!mover || !mover->IsInWorld() || mover->IsDuringRemoveFromWorld() || guid != mover->GetGUID())
     {
-        recvData.rfinish();
+        recvData.rfinish();                     // prevent warnings spam
         return;
     }
 
@@ -330,13 +330,19 @@ void WorldSession::HandleMovementOpcodes(WorldPacket & recvData)
     movementInfo.guid = guid;
     ReadMovementInfo(recvData, &movementInfo);
 
+    recvData.rfinish();                         // prevent warnings spam
+
     if (!movementInfo.pos.IsPositionValid())
     {
         recvData.rfinish();                     // prevent warnings spam
         return;
     }
 
-    recvData.rfinish();                         // prevent warnings spam
+    if (!mover->movespline->Finalized())
+    {
+        recvData.rfinish();                     // prevent warnings spam
+        return;
+    }
 
     if (movementInfo.flags & MOVEMENTFLAG_ONTRANSPORT)
     {


### PR DESCRIPTION
##### Current behaviour:

Warrior appears like teleporting, the charge animation starts, then warrior moves about 2-3 yards forward, then gets back, and immediately teleported to the target after that.

##### Expected behaviour:

Charge animation should be smooth.

##### HOW TO TEST THE CHANGES:

1. Make Warrior
2. Make another character as target
3. Jump backwards and immediately press charge

Charge animation always looks smooth on the warrior's client, but very weird and broken on the target's client (this is not always happening, this macro to reproduce it easily:

> /cast charge
> /target player
> .cool
> /targetlasttarget
